### PR TITLE
Support resetting of contention metric, fix deadlocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "gil-knocker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "parking_lot",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gil-knocker"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[deny(missing_docs)]
 use parking_lot::{const_rwlock, RwLock};
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::ffi::{PyEval_InitThreads, PyEval_ThreadsInitialized};
 use pyo3::prelude::*;
 use pyo3::{
     exceptions::{PyBrokenPipeError, PyTimeoutError, PyValueError},
@@ -23,6 +24,12 @@ fn gilknocker(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
+/// Possible messages to pass to the monitoring thread.
+enum Message {
+    Stop,
+    Reset,
+}
+
 /// Struct for polling, knocking on the GIL,
 /// checking if it's locked in the current thread
 ///
@@ -40,7 +47,7 @@ fn gilknocker(_py: Python, m: &PyModule) -> PyResult<()> {
 #[derive(Default)]
 pub struct KnockKnock {
     handle: Option<thread::JoinHandle<()>>,
-    channel: Option<Sender<bool>>,
+    channel: Option<Sender<Message>>,
     contention_metric: Option<Arc<RwLock<f32>>>,
     interval: Duration,
     timeout: Duration,
@@ -76,22 +83,50 @@ impl KnockKnock {
         self.contention_metric.as_ref().map(|v| *(*v).read())
     }
 
+    /// Reset the contention metric/monitoring state
+    pub fn reset_contention_metric(&mut self) -> PyResult<()> {
+        match &self.channel {
+            Some(channel) => channel
+                .send(Message::Reset)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string())),
+            None => Err(PyValueError::new_err(
+                "Does not appear `start` was called, nothing to reset.",
+            )),
+        }
+    }
+
     /// Start polling the GIL to check if it's locked.
     pub fn start(&mut self, py: Python) -> () {
         let (send, recv) = channel();
         self.channel = Some(send);
 
+        unsafe {
+            if PyEval_ThreadsInitialized() == 0 {
+                PyEval_InitThreads();
+            }
+        }
+
         let contention_metric = Arc::new(const_rwlock(0_f32));
         self.contention_metric = Some(contention_metric.clone());
+
         let interval = self.interval;
         let handle = py.allow_threads(move || {
             thread::spawn(move || {
                 let mut time_to_acquire = Duration::from_millis(0);
-                let runtime = Instant::now();
-                while recv
-                    .recv_timeout(interval)
-                    .unwrap_or_else(|e| e != RecvTimeoutError::Disconnected)
-                {
+                let mut runtime = Instant::now();
+                loop {
+                    match recv.recv_timeout(interval) {
+                        Ok(message) => match message {
+                            Message::Stop => break,
+                            Message::Reset => {
+                                time_to_acquire = Duration::from_millis(0);
+                                runtime = Instant::now();
+                                *(*contention_metric).write() = 0_f32;
+                            }
+                        },
+                        Err(RecvTimeoutError::Disconnected) => break,
+                        Err(RecvTimeoutError::Timeout) => {}
+                    }
                     let start = Instant::now();
                     time_to_acquire += Python::with_gil(move |_py| start.elapsed());
                     {
@@ -110,7 +145,7 @@ impl KnockKnock {
         match take(&mut self.handle) {
             Some(handle) => {
                 if let Some(send) = take(&mut self.channel) {
-                    send.send(false)
+                    send.send(Message::Stop)
                         .map_err(|e| PyBrokenPipeError::new_err(e.to_string()))?;
 
                     let start = Instant::now();

--- a/tests/test_knockknock.py
+++ b/tests/test_knockknock.py
@@ -9,7 +9,7 @@ N_THREADS = 4
 N_PTS = 4096
 
 
-def flaky(n_tries=10):
+def flaky(n_tries=5):
     def wrapper(func):
         def _wrapper(*args, **kwargs):
             for _ in range(n_tries - 1):
@@ -83,6 +83,19 @@ def test_knockknock_available_gil():
     try:
         # usually ~0.001 on linux and ~0.05 on windows
         assert knocker.contention_metric < 0.06
+    finally:
+        knocker.stop()
+
+
+@flaky()
+def test_knockknock_reset_contention_metric():
+    knocker = _run(a_lotta_gil)
+
+    try:
+        assert knocker.contention_metric > 0.6
+        knocker.reset_contention_metric()
+        assert knocker.contention_metric < 0.001
+
     finally:
         knocker.stop()
 


### PR DESCRIPTION
- Support method `reset_contention_metric()` which resets the contention metric and timers.
- Fix deadlocking by internally spawning a thread specifically to try and obtain the GIL. This allows the monitoring thread to remain available for receiving messages.
  - Thereby also removing the `flaky` decorator and `xfail` markers.

Ref https://github.com/dask/distributed/issues/7290#issuecomment-1385998993