### PR TITLE
Restore building of universal mac wheel for m1/m2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,11 +28,17 @@ jobs:
         with:
           targets: aarch64-apple-darwin
       - name: Build wheels - x86_64
+        if: ${{ matrix.python-version == '3.7' }}
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
           args: -i python --release --out dist --sdist
-      - name: Install built wheel - x86_64
+      - name: Build wheels - universal2
+        if: ${{ matrix.python-version != '3.7' }}
+        uses: PyO3/maturin-action@v1
+        with:
+          args: -i python --release --out dist --target universal2-apple-darwin
+      - name: Install built wheel
         run: |
           pip install gilknocker --no-index --find-links dist --force-reinstall
       - name: Python UnitTest
@@ -43,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist        
+          path: dist
 
   windows:
     runs-on: windows-latest
@@ -83,7 +89,7 @@ jobs:
         with:
           name: wheels
           path: dist
-        
+
   linux:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
When trying to install this package on an M1 Mac system I encountered the following error:

```
Collecting gilknocker>=0.4.1 (from coiled)
  Using cached gilknocker-0.4.1.tar.gz (26 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]

      Cargo, the Rust package manager, is not installed or is not on PATH.
      This package requires Rust and Cargo to compile extensions. Install it through
      the system's package manager or via https://rustup.rs/

      Checking for Rust toolchain....
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

It appears that aarch64-compatible wheels are missing for the 0.4.1 version of this package.

Digging further into the issue, I found that the [previous commit adding python 3.12 wheel builds](https://github.com/milesgranger/gilknocker/commit/b920ead8b0cececa788a508b3423966c9b49af93#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L37) removed the universal wheel builds. It seemed this change was likely based on two factors:

1. the `--universal2` build option for matruin has been removed and now `--target universal2-apple-darwin` should be used
2. the condition used to exclude python 3.7 from the universal build was overly complex and effectively duplicates the python version in the matrix, sans 3.7

This PR resolves both those issues. Now, an x86_64 wheel is only built for 3.7, while all other python versions build universal wheels.