### PR TITLE
Ensure 3.13 aarch64 wheel gets built too and clean up a few things in CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Build wheels - universal2
         uses: PyO3/maturin-action@v1
         with:
-          args: -i python --release --out dist --target universal2-apple-darwin
+          target: universal2-apple-darwin
+          args: -i python --release --out dist
       - name: Install built wheel
         run: |
           pip install gilknocker --no-index --find-links dist --force-reinstall
@@ -60,7 +61,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build wheels
-        uses: messense/maturin-action@v1
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: -i python --release --out dist
@@ -132,7 +133,6 @@ jobs:
     - name: Build Wheels - gilknocker
       uses: PyO3/maturin-action@v1
       with:
-        target: ${{ matrix.target }}
         manylinux: auto
         args: -i ${{ matrix.python-version }} --release --out dist
     - name: Python UnitTest - gilknocker
@@ -172,7 +172,6 @@ jobs:
     - name: Build Wheels - gilknocker
       uses: PyO3/maturin-action@v1
       with:
-        target: ${{ matrix.target }}
         manylinux: auto
         args: -i ${{ matrix.python-version }} --release --out dist
     - name: Install wheel
@@ -197,6 +196,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         target: [aarch64, armv7, s390x, ppc64le]
         include:
           - python-version: pypy3.8
@@ -236,7 +236,7 @@ jobs:
           apt-get install -y --no-install-recommends python3 python3-venv software-properties-common
           add-apt-repository ppa:deadsnakes/ppa
           apt-get update
-          apt-get install -y curl python3.9-venv python3.10-venv python3.11-venv python3.12-venv
+          apt-get install -y curl python3.9-venv python3.10-venv python3.11-venv python3.12-venv python3.13-venv
         run: |
           ls -lrth /artifacts
           PYTHON=python${{ matrix.python-version }}
@@ -253,7 +253,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [ macos, windows, linux ]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
I realized I forgot to add 3.13 to the linux-cross section of `CI.yml` so there's no `aarch64` 3.13 wheels currently.

I also noticed a couple little consistency things in the `CI.yml` file that I fixed while I was at it.