### PR TITLE
fix: builds missing wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -246,8 +246,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [macos, windows, linux]
+    needs: [macos, windows, linux, linux-cross, pypy-linux, pypy-macos]
     steps:
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v5
         with:
           pattern: wheels-*
@@ -255,10 +256,15 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
       - name: Publish to PyPi
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}
         run: |
           pip install --upgrade wheel pip setuptools twine
-          twine upload --skip-existing *
+          twine upload --skip-existing dist/*


### PR DESCRIPTION
The missing `needs` entries I think are the culprit for the missing wheels in the 0.4.2 release and the extra sdist step should make sure there's an sdist included in the release.

🤞 